### PR TITLE
build inside of $GOPATH

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,16 +9,23 @@ license=('MIT')
 makedepends=('go')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/direnv/direnv/archive/v$pkgver.tar.gz")
 
-build() {
-  cd "$srcdir/$pkgname-$pkgver"
+gopackagepath=github.com/direnv/direnv
 
+prepare() {
   [[ -f /etc/profile.d/go.sh ]] && source /etc/profile.d/go.sh
+  export GOPATH=$srcdir/go
+
+  mkdir -p "$GOPATH/$(dirname "$gopackagepath")"
+  mv "$srcdir/$pkgname-$pkgver" "$GOPATH/$gopackagepath"
+}
+
+build() {
+  cd "$GOPATH/$gopackagepath"
   make
 }
 
 package() {
-  cd "$srcdir/$pkgname-$pkgver"
-
+  cd "$GOPATH/$gopackagepath"
   make install DESTDIR=$pkgdir/usr
 }
 


### PR DESCRIPTION
The newest version of direnv has dependencies. This updates the build method to actually checkout the project in the right place inside of $GOPATH.

Can someone please test this?