### PR TITLE
GOPATH needs to be exported to make direnv

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -20,11 +20,13 @@ prepare() {
 }
 
 build() {
+  export GOPATH=$srcdir/go
   cd "$GOPATH/src/$gopackagepath"
   make
 }
 
 package() {
+  export GOPATH=$srcdir/go
   cd "$GOPATH/src/$gopackagepath"
   make install DESTDIR=$pkgdir/usr
 }


### PR DESCRIPTION
This fixed 2.12.2-1 for me.

Note sure if the `/etc/profile.d/go.sh` needs to be sourced too, but GOPATH must be visible to `make` command.