### PR TITLE
Change build process to meet Arch's guidelines

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 # Maintainer: rmorgans <rick.morgans@gmail.com>
 pkgname=direnv
 pkgver=2.21.3
-pkgrel=1
+pkgrel=2
 pkgdesc='a shell extension that manages your environment'
 arch=('x86_64' 'i686' 'armv7h')
 url='https://direnv.net'
@@ -14,23 +14,25 @@ sha256sums=('012651a79e47150de4a386d1c3c81a017d5ceac14f5a0c24b0596a2215cde8be')
 
 _gopackagepath=github.com/direnv/direnv
 
-prepare() {
-  [[ -f /etc/profile.d/go.sh ]] && source /etc/profile.d/go.sh
-  export GOPATH="$srcdir/go"
-
-  mkdir -p "$GOPATH/src/$(dirname "$_gopackagepath")"
-  mv "$srcdir/$pkgname-$pkgver" "$GOPATH/src/$_gopackagepath"
+build() {
+  cd "$pkgname-$pkgver"
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export GOFLAGS="-buildmode=pie -trimpath -mod=vendor -modcacherw"
+  go build -o $pkgname
 }
 
-build() {
-  export GOPATH="$srcdir/go"
-  cd "$GOPATH/src/$_gopackagepath"
-  make
+check() {
+  cd "$pkgname-$pkgver"
+  go test -v
+  bash ./test/direnv-test.bash
+  ./test/stdlib.bash
 }
 
 package() {
-  export GOPATH="$srcdir/go"
-  cd "$GOPATH/src/$_gopackagepath"
+  cd "$pkgname-$pkgver"
   make install DESTDIR="$pkgdir/usr"
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
According to [1] some GOFLAGS and CGO_ flags have to be set.
Change the build process so it reflects the changes described there.

Also add check simple check routine.

[1]: https://wiki.archlinux.org/index.php/Go_package_guidelines